### PR TITLE
chore: Move puck content to the same shadow DOM tree

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -7,17 +7,8 @@
   font-family: Meiryo, sans-serif;
 }
 
-.window {
-  max-width: 600px;
-  contain: content;
-  border-radius: 5px;
-  box-shadow: 2px 2px 1px rgba(100, 100, 100, 0.25);
-  font: normal 14px sans-serif;
-
-  color: var(--text-color);
-  background: var(--bg-color);
-  border: 1px solid var(--border-color);
-
+:root,
+:host {
   --tag-green: #43a047aa;
   --tag-pink: #f24b59aa;
   --tag-blue: #2698fbaa;
@@ -29,6 +20,44 @@
   --selected-def-color: #1a1d1f;
   --selected-tag-color: #1a1d1f;
   --selected-tag-border: rgba(0, 0, 0, 0.3);
+}
+
+/* ---------------------------------------------------------------------------
+ *
+ * Popup window
+ *
+ * -------------------------------------------------------------------------- */
+
+#popup {
+  position: absolute;
+  /* asahi.com puts z-index: 1000000 on its banner ads. We go one better. */
+  z-index: 1000001;
+  /* Make sure the drop shadow doesn't get cut off */
+  padding-right: 4px;
+  padding-bottom: 4px;
+
+  /* Set initial position */
+  top: 5px;
+  left: 5px;
+  min-width: 100px;
+
+  /* Enforce any max-height set on the popup container. */
+  overflow-y: hidden;
+
+  /* Make sure the popup container too doesn't receive pointer events */
+  pointer-events: none;
+}
+
+.window {
+  max-width: 600px;
+  contain: content;
+  border-radius: 5px;
+  box-shadow: 2px 2px 1px rgba(100, 100, 100, 0.25);
+  font: normal 14px sans-serif;
+
+  color: var(--text-color);
+  background: var(--bg-color);
+  border: 1px solid var(--border-color);
 }
 
 .window.hidden {
@@ -675,12 +704,41 @@
   padding-right: 5px;
 }
 
+/* ---------------------------------------------------------------------------
+ *
+ * Puck
+ *
+ * -------------------------------------------------------------------------- */
+
+#puck {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 50px;
+  height: 50px;
+  box-sizing: border-box;
+  /* We use a z-index one higher than the popup */
+  z-index: 1000002;
+  touch-action: manipulation;
+  background: var(--bg-color);
+  border: 2px solid var(--border-color);
+  border-radius: 15px;
+}
+
+/* ---------------------------------------------------------------------------
+ *
+ * Themes
+ *
+ * -------------------------------------------------------------------------- */
+
 /*
  * Theme - light
  */
 
 .window,
-.window.-light {
+#puck,
+.window.-light,
+#puck.-light {
   --text-color: #1d1a19;
   --bg-color: #f6f1f0;
   --border-color: #706c6b;
@@ -707,7 +765,8 @@
  * Theme - blue
  */
 
-.window.-blue {
+.window.-blue,
+#puck.-blue {
   --text-color: white;
   --bg-color: #446ea0;
   --border-color: #17588e;
@@ -736,7 +795,8 @@
  * Theme - black
  */
 
-.window.-black {
+.window.-black,
+#puck.-black {
   --text-color: white;
   --bg-color: #3e3a39;
   --border-color: #999493;
@@ -769,7 +829,8 @@
  * Theme - lightblue
  */
 
-.window.-lightblue {
+.window.-lightblue,
+#puck.-lightblue {
   --text-color: #1d1a19;
   --bg-color: #e3f2fe;
   --border-color: #65b7fc;
@@ -798,7 +859,8 @@
  * Theme - yellow
  */
 
-.window.-yellow {
+.window.-yellow,
+#puck.-yellow {
   --text-color: #1d1a19;
   --bg-color: #fff8bf;
   --border-color: #ffd600;

--- a/html/options.js
+++ b/html/options.js
@@ -199,7 +199,7 @@ function completeForm() {
     label.setAttribute('for', `popupstyle-${theme}`);
     popupStyleSelect.appendChild(label);
     const popupPreview = document.createElement('div');
-    popupPreview.setAttribute('id', 'tenten-ja-window');
+    popupPreview.setAttribute('id', 'tenten-ja-content');
     popupPreview.classList.add('popup-preview');
     popupPreview.classList.add(`-${theme}`);
     label.appendChild(popupPreview);

--- a/src/content-container.ts
+++ b/src/content-container.ts
@@ -1,0 +1,192 @@
+import { getHash } from './hash';
+import { isForeignObjectElement, isSvgDoc, SVG_NS } from './svg';
+
+import contentStyles from '../css/popup.css';
+import { getPopupWindow } from './popup';
+
+export function getOrCreateContentContainer(doc: Document): HTMLElement {
+  // Drop any legacy containers
+  const legacyContainers = doc.querySelectorAll(
+    '#rikaichamp-window, #tenten-ja-window'
+  );
+  for (const container of legacyContainers) {
+    removeContentContainer(container);
+  }
+
+  // Look for an existing container we can re-use
+  const existingContainers = Array.from<HTMLElement>(
+    doc.querySelectorAll('#tenten-ja-content')
+  );
+  if (existingContainers.length) {
+    // Drop any duplicate containers, returning only the last one
+    while (existingContainers.length > 1) {
+      removeContentContainer(existingContainers.shift()!);
+    }
+
+    // Make sure the styles are up-to-date
+    resetStyles({ container: existingContainers[0], doc });
+
+    return existingContainers[0];
+  }
+
+  // Create a new content container
+
+  // For SVG documents we put container <div> inside a <foreignObject>.
+  let parent: Element;
+  if (isSvgDoc(doc)) {
+    const foreignObject = doc.createElementNS(SVG_NS, 'foreignObject');
+    foreignObject.setAttribute('width', '100%');
+    foreignObject.setAttribute('height', '100%');
+    doc.documentElement.append(foreignObject);
+    parent = foreignObject;
+  } else {
+    parent = doc.documentElement;
+  }
+
+  // Actually create the container element
+  const container = doc.createElement('div');
+  container.id = 'tenten-ja-content';
+  parent.append(container);
+
+  // Reset any styles the page may have applied.
+  container.style.all = 'initial';
+
+  // Add the necessary styles
+  resetStyles({ container, doc });
+
+  return container;
+}
+
+export function getOrCreateEmptyPopupContainer(doc: Document): HTMLElement {
+  const contentContainer = getOrCreateContentContainer(doc);
+
+  // Drop any existing popup container -- for now we never need to re-use the
+  // popup container so it's simpler to just drop it and rebuild it if it exists
+  const existingPopupContainers = Array.from<Element>(
+    contentContainer.shadowRoot!.querySelectorAll('#popup')
+  );
+  while (existingPopupContainers.length) {
+    existingPopupContainers.pop()!.remove();
+  }
+
+  // Create the popup container
+  const popupContainer = doc.createElement('div');
+  popupContainer.id = 'popup';
+  contentContainer.shadowRoot!.append(popupContainer);
+
+  // Reset the container position and size so that we can consistently measure
+  // the size of the popup.
+  popupContainer.style.removeProperty('left');
+  popupContainer.style.removeProperty('top');
+  popupContainer.style.removeProperty('max-width');
+  popupContainer.style.removeProperty('max-height');
+
+  return popupContainer;
+}
+
+export function getPopupContainer(doc: Document): HTMLElement | null {
+  const contentContainer = doc.getElementById('tenten-ja-content');
+  return contentContainer && contentContainer.shadowRoot
+    ? contentContainer.shadowRoot.querySelector('#popup')
+    : null;
+}
+
+export function removePopupContainer() {
+  const popupContainer = document.querySelector('#tenten-ja-content #popup');
+  if (popupContainer) {
+    popupContainer.remove();
+  }
+}
+
+export function removeAllContent() {
+  const containers = Array.from<HTMLElement>(
+    document.querySelectorAll(
+      '#rikaichamp-window, #tenten-ja-window, #tenten-ja-content'
+    )
+  );
+  for (const container of containers) {
+    removeContentContainer(container);
+  }
+}
+
+export function setContentStyle(style: string) {
+  const content = [getPopupWindow(), getPuck()].filter(
+    Boolean
+  ) as Array<HTMLElement>;
+
+  for (const elem of content) {
+    // Theme classes (and only theme classes) start with a '-'
+    for (const className of elem.classList.values() || []) {
+      if (className.startsWith('-')) {
+        elem.classList.remove(className);
+      }
+    }
+    elem.classList.add(`-${style}`);
+  }
+}
+
+// --------------------------------------------------------------------------
+//
+// Implementation helpers
+//
+// --------------------------------------------------------------------------
+
+function removeContentContainer(elem: Element) {
+  console.trace('Removing content container');
+  if (isForeignObjectElement(elem.parentElement)) {
+    elem.parentElement.remove();
+  } else {
+    elem.remove();
+  }
+}
+
+function resetStyles({
+  container,
+  doc,
+}: {
+  container: HTMLElement;
+  doc: Document;
+}) {
+  if (!container.shadowRoot) {
+    container.attachShadow({ mode: 'open' });
+
+    // Add <style>
+    const style = doc.createElement('style');
+    style.textContent = contentStyles;
+    style.dataset.hash = getStyleHash();
+    container.shadowRoot!.append(style);
+  } else {
+    // Reset style
+    let existingStyle = container.shadowRoot.querySelector('style');
+    if (existingStyle && existingStyle.dataset.hash !== getStyleHash()) {
+      existingStyle.remove();
+      existingStyle = null;
+    }
+
+    if (!existingStyle) {
+      const style = doc.createElement('style');
+      style.textContent = contentStyles;
+      style.dataset.hash = getStyleHash();
+      container.shadowRoot!.append(style);
+    }
+  }
+}
+
+let styleHash: string | undefined;
+
+function getStyleHash(): string {
+  if (!styleHash) {
+    styleHash = getHash(contentStyles.toString());
+  }
+
+  return styleHash;
+}
+
+function getPuck(): HTMLElement | null {
+  const contentContainer = document.getElementById('tenten-ja-content');
+  if (!contentContainer || !contentContainer.shadowRoot) {
+    return null;
+  }
+
+  return contentContainer.shadowRoot.getElementById('puck');
+}

--- a/src/get-text.ts
+++ b/src/get-text.ts
@@ -47,7 +47,7 @@ export function getTextAtPoint(
   point: Point,
   maxLength?: number
 ): GetTextAtPointResult | null {
-  let position = carentPositionFromPoint(point);
+  let position = caretPositionFromPoint(point);
 
   // Chrome not only doesn't support caretPositionFromPoint, but also
   // caretRangeFromPoint doesn't return text input elements. Instead it returns
@@ -199,7 +199,7 @@ export function getTextAtPoint(
   return null;
 }
 
-function carentPositionFromPoint(point: Point): CursorPosition | null {
+function caretPositionFromPoint(point: Point): CursorPosition | null {
   if (document.caretPositionFromPoint) {
     return document.caretPositionFromPoint(point.x, point.y);
   }
@@ -603,7 +603,7 @@ function getTextFromCoveringLink({
   const previousPointEvents = linkElem.style.pointerEvents;
   linkElem.style.pointerEvents = 'none';
 
-  const position = carentPositionFromPoint(point);
+  const position = caretPositionFromPoint(point);
 
   linkElem.style.pointerEvents = previousPointEvents;
 

--- a/src/puck.ts
+++ b/src/puck.ts
@@ -1,111 +1,124 @@
-export interface PuckOpts {
-  width: number;
-  height: number;
-  borderColor: string;
-  backgroundColor: string;
-}
+import { getOrCreateContentContainer } from './content-container';
 
 export class RikaiPuck {
-  private readonly puck: HTMLDivElement = document.createElement("div");
-  private static defaultOpts: PuckOpts = {
-    width: 50,
-    height: 50,
-    borderColor: "#b7e7ff",
-    backgroundColor: "#5c73b8",
-  };
-  private _puckX: number;
-  private get puckX(): number {
-    return this._puckX;
-  }
-  private set puckX(x: number){
-    this._puckX = x;
-    this.puck.style.transform = `translate(${x}px, ${this.puckY}px)`;
-  }
-  private _puckY: number;
-  private get puckY(): number {
-    return this._puckY;
-  }
-  private set puckY(y: number){
-    this._puckY = y;
-    this.puck.style.transform = `translate(${this.puckX}px, ${y}px)`;
+  private puckElem: HTMLElement | undefined;
+  private enabled = false;
+
+  private puckX: number;
+  private puckY: number;
+  private setPosition(x: number, y: number) {
+    this.puckX = x;
+    this.puckY = y;
+    if (this.puckElem) {
+      this.puckElem.style.transform = `translate(${this.puckX}px, ${this.puckY}px)`;
+    }
   }
 
-  private _puckWidth: number;
-  private get puckWidth(): number {
-    return this._puckWidth;
-  }
-  private set puckWidth(width: number){
-    this._puckWidth = width;
-    this.puck.style.width = `${width}px`;
-  }
-  private _puckHeight: number;
-  private get puckHeight(): number {
-    return this._puckHeight;
-  }
-  private set puckHeight(height: number){
-    this._puckHeight = height;
-    this.puck.style.height = `${height}px`;
-  }
+  private puckWidth: number;
+  private puckHeight: number;
 
-  constructor(opts: Partial<PuckOpts> = RikaiPuck.defaultOpts){
-    const {
-      width,
-      height,
-      backgroundColor,
-      borderColor,
-    } = Object.assign({}, RikaiPuck.defaultOpts, opts);
+  private readonly onPointerMove = (event: PointerEvent) => {
+    if (!this.puckWidth || !this.puckHeight || !this.enabled) {
+      return;
+    }
 
-    this.puck.style.position = "fixed";
-    this.puckWidth = width;
-    this.puckHeight = height;
-    this.puck.style.top = "0";
-    this.puck.style.left = "0";
-    this.puck.style.boxSizing = "border-box";
-    this.puck.style.backgroundColor = backgroundColor;
-    this.puck.style.touchAction = "manipulation";
-    this.puck.style.borderRadius = "15px";
-    this.puck.style.border = `2px solid ${borderColor}`;
-    // We use a z-index one higher than the Rikai popup itself.
-    this.puck.style.zIndex = "1000002";
-  }
-  private readonly onPointermove = (event: PointerEvent) => {
     event.preventDefault();
-    const { clientX, clientY } = event;
-    this.puckX = clientX - this.puckWidth / 2;
-    this.puckY = clientY - this.puckHeight / 2;
-    window.dispatchEvent(
-      new MouseEvent(
-        "mousemove",
-        {
-          clientX: this.puckX,
-          // Offset by at least one pixel so that Rikai doesn't attempt to tunnel into the puck rather than the text.
-          clientY: this.puckY - 1,
-        }
-      )
-    );
-  }
 
-  render(parent: HTMLElement): void {
-    const viewportWidth = document.documentElement.clientWidth;
-    const viewportHeight = document.documentElement.clientHeight;
+    // Work out where the puck should be
+    const { clientX, clientY } = event;
+    this.setPosition(
+      clientX - this.puckWidth / 2,
+      clientY - this.puckHeight / 2
+    );
+
+    // Work out where we want to lookup
+    const targetX = this.puckX;
+    // Offset by at least one pixel so that Rikai doesn't attempt to tunnel into
+    // the puck rather than the text.
+    const targetY = this.puckY - 1;
+
+    // Make sure the target is an actual element since the mousemove handler
+    // expects that.
+    const target = document.elementFromPoint(targetX, targetY);
+    if (target) {
+      target.dispatchEvent(
+        new MouseEvent('mousemove', {
+          // Make sure the event bubbles up to the listener on the window
+          bubbles: true,
+          clientX: targetX,
+          clientY: targetY,
+        })
+      );
+    }
+  };
+
+  // Prevent any mouse events on the puck itself from being used for lookup.
+  //
+  // At least in Firefox Responsive Design Mode (with touch simulation disabled)
+  // we can get _both_ pointer events and mouse events being dispatched.
+  private readonly onMouseMove = (event: MouseEvent) => {
+    event.stopPropagation();
+  };
+
+  render(doc: Document): void {
+    // Remove any existing pucks (e.g. if we are upgrading and failed to clean
+    // up last time).
+    const contentContainer = getOrCreateContentContainer(doc);
+    const existingPucks = Array.from<Element>(
+      contentContainer.shadowRoot!.querySelectorAll('#puck')
+    );
+    while (existingPucks.length) {
+      existingPucks.pop()!.remove();
+    }
+
+    // Create the new puck
+    this.puckElem = doc.createElement('div');
+    this.puckElem.id = 'puck';
+    contentContainer.shadowRoot!.append(this.puckElem);
+
+    // Calculate its size
+    if (!this.puckWidth || !this.puckHeight) {
+      const { width, height } = this.puckElem.getBoundingClientRect();
+      this.puckWidth = width;
+      this.puckHeight = height;
+    }
+
+    // Calculate its initial position
+    const viewportWidth = doc.documentElement.clientWidth;
+    const viewportHeight = doc.documentElement.clientHeight;
     const safeAreaInsetRight = 16; // TODO: calculate properly
     const safeAreaInsetBottom = 200; // TODO: calculate properly
-    this.puckX = viewportWidth - this.puckWidth - safeAreaInsetRight;
-    this.puckY = viewportHeight - this.puckHeight - safeAreaInsetBottom;
+    this.setPosition(
+      viewportWidth - this.puckWidth - safeAreaInsetRight,
+      viewportHeight - this.puckHeight - safeAreaInsetBottom
+    );
 
-    parent.appendChild(this.puck);
-  }
-
-  unmount(): void {
-    this.puck.parentElement?.removeChild(this.puck);
-    this.disable();
+    // Add event listeners
+    if (this.enabled) {
+      this.puckElem.addEventListener('pointermove', this.onPointerMove);
+      this.puckElem.addEventListener('mousemove', this.onMouseMove, {
+        capture: true,
+      });
+    }
   }
 
   enable(): void {
-    this.puck.addEventListener("pointermove", this.onPointermove);
+    this.enabled = true;
+    if (this.puckElem) {
+      this.puckElem.addEventListener('pointermove', this.onPointerMove);
+      this.puckElem.addEventListener('mousemove', this.onMouseMove, {
+        capture: true,
+      });
+    }
   }
 
   disable(): void {
-    this.puck.removeEventListener("pointermove", this.onPointermove);
+    this.enabled = false;
+    if (this.puckElem) {
+      this.puckElem.removeEventListener('pointermove', this.onPointerMove);
+      this.puckElem.removeEventListener('mousemove', this.onMouseMove, {
+        capture: true,
+      });
+    }
   }
 }


### PR DESCRIPTION
Here's my work so far on moving the puck content to a shadow DOM tree. I had to do some fairly significant rework to get things working locally for me. Mouse interaction now works (in so far as I think we intend it to work at this point) but in the process I probably broke regular touch interaction 😅

Some other potential problems with this PR:

* I haven't tested SVG content where the document itself is an SVG document. It's quite possible I broke that.
* I probably made a few cosmetic changes that aren't strictly necessary.
* I should rename `popup.css` to `content.css` but that can be a separate patch.
* There was something else but now I forget... 😅

The event handler registration part is pretty clumsy. But we probably need to work out what "enabling" actually means. I think there are at least three states here:

* Puck showing and looking things up
* Puck showing but not looking things up
* Puck absent

Once we work out that, we might rework how the event registration part works.

I had to change the `DOMContentLoaded` part since we need to run that puck init code even if the `readyState` is `complete`.

Also, I had to rework the event dispatching somewhat because currently the content script expects the event target to be an Element, not a Window so the pop-up positioning code was getting tripped up on that.

Also, while it might be nice to set the theme on a single ancestor element and have it apply to both popup and puck simultaneously, that interferes a bit with the test setup we have in `popups.html` so for now I've just made it set the theme class on both the popup and puck separately.