### PR TITLE
chore: Move Puck styles to a separate shadow DOM tree

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -1,10 +1,26 @@
 @charset "UTF-8";
+@import 'themes.css';
 
 *:lang(en),
 *:lang(fr),
 *:lang(es) {
   /* Meiryo renders more crisply than Arial on Windows */
   font-family: Meiryo, sans-serif;
+}
+
+:host {
+  position: absolute !important;
+  /* asahi.com puts z-index: 1000000 on its banner ads. We go one better. */
+  z-index: 1000001 !important;
+  /* Make sure the drop shadow doesn't get cut off */
+  padding-right: 4px !important;
+  padding-bottom: 4px !important;
+
+  /* Enforce any max-height set on the popup container. */
+  overflow-y: hidden !important;
+
+  /* Make sure the popup container too doesn't receive pointer events */
+  pointer-events: none !important;
 }
 
 .window {
@@ -673,153 +689,4 @@
 .wordlist .meta .equals {
   padding-left: 5px;
   padding-right: 5px;
-}
-
-/*
- * Theme - light
- */
-
-.window,
-.window.-light {
-  --text-color: #1d1a19;
-  --bg-color: #f6f1f0;
-  --border-color: #706c6b;
-
-  --primary-highlight: #1f66c7;
-  --reading-highlight: #43a047;
-  --conj-color: #1a47a8;
-
-  --tag-border: rgba(0, 0, 0, 0.3);
-
-  --title-fg: var(--text-color);
-  --title-bg: #ddd8d7;
-
-  --reading-label: #1b5e20;
-  --okurigana-color: #fc7600;
-  --cell-highlight-bg: #ede8e6;
-  --cell-highlight-fg: #1d1a19;
-
-  --meta-bg: var(--cell-highlight-bg);
-  --copy-status-bg: var(--cell-highlight-bg);
-}
-
-/*
- * Theme - blue
- */
-
-.window.-blue {
-  --text-color: white;
-  --bg-color: #446ea0;
-  --border-color: #17588e;
-
-  --primary-highlight: #bcdffe;
-  --reading-highlight: #c0ffc0;
-  --conj-color: #fff394;
-
-  --tag-border: rgba(255, 255, 255, 0.4);
-
-  --title-bg: var(--cell-highlight-bg);
-  --title-fg: var(--text-color);
-
-  --reading-label: #e7ffe7;
-  --okurigana-color: #a8cfef;
-  --cell-highlight-bg: #17588e;
-  --cell-highlight-fg: var(--primary-highlight);
-
-  --selected-highlight: var(--bg-color);
-
-  --copy-status-bg: rgba(255, 255, 255, 0.2);
-  --meta-bg: rgba(255, 255, 255, 0.2);
-}
-
-/*
- * Theme - black
- */
-
-.window.-black {
-  --text-color: white;
-  --bg-color: #3e3a39;
-  --border-color: #999493;
-
-  --primary-highlight: #65b7fc;
-  --reading-highlight: #a5d6a7;
-  --conj-color: #817470;
-
-  --tag-border: rgba(255, 255, 255, 0.4);
-
-  --title-bg: #1d1a19;
-  --title-fg: #ede8e6;
-
-  --reading-label: #e7ffe7;
-  --okurigana-color: #ede8e6;
-  --cell-highlight-bg: #5d5857;
-  --cell-highlight-fg: #ede8e6;
-
-  --selected-highlight: #2277d9;
-
-  --copy-status-bg: rgba(255, 255, 255, 0.2);
-  --meta-bg: rgba(255, 255, 255, 0.2);
-}
-
-.window.-black .kanji-table:not(.-copy) .kanji {
-  text-shadow: rgba(255, 255, 255, 0.2) 1px 1px 4px;
-}
-
-/*
- * Theme - lightblue
- */
-
-.window.-lightblue {
-  --text-color: #1d1a19;
-  --bg-color: #e3f2fe;
-  --border-color: #65b7fc;
-
-  --primary-highlight: #17588e;
-  --reading-highlight: #2e7d32;
-  --conj-color: #817470;
-
-  --tag-border: rgba(0, 0, 0, 0.3);
-
-  --title-fg: var(--text-color);
-  --title-bg: #bcdffe;
-
-  --reading-label: #1b5e20;
-  --okurigana-color: #706c6b;
-  --cell-highlight-bg: #cae6fc;
-  --cell-highlight-fg: var(--primary-highlight);
-
-  --selected-highlight: var(--primary-highlight);
-
-  --meta-bg: var(--cell-highlight-bg);
-  --copy-status-bg: var(--cell-highlight-bg);
-}
-
-/*
- * Theme - yellow
- */
-
-.window.-yellow {
-  --text-color: #1d1a19;
-  --bg-color: #fff8bf;
-  --border-color: #ffd600;
-
-  --primary-highlight: #17588e;
-  --reading-highlight: #2e7d32;
-  --conj-color: #fc7600;
-
-  --tag-border: rgba(0, 0, 0, 0.3);
-
-  --title-bg: #fffde5;
-  --title-fg: var(--text-color);
-
-  --reading-label: #1b5e20;
-  --okurigana-color: #fc7600;
-  --cell-highlight-bg: #fffde5;
-  --cell-highlight-fg: #3e3a39;
-
-  --selected-bg: #e3f2fe;
-  --selected-highlight: var(--primary-highlight);
-
-  --meta-bg: var(--cell-highlight-bg);
-  --copy-status-bg: var(--cell-highlight-bg);
 }

--- a/css/puck.css
+++ b/css/puck.css
@@ -1,0 +1,17 @@
+@charset "UTF-8";
+@import 'themes.css';
+
+.puck {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 50px;
+  height: 50px;
+  box-sizing: border-box;
+  /* We use a z-index one higher than the popup */
+  z-index: 1000002;
+  touch-action: manipulation;
+  background: var(--bg-color);
+  border: 2px solid var(--border-color);
+  border-radius: 15px;
+}

--- a/css/themes.css
+++ b/css/themes.css
@@ -1,0 +1,171 @@
+@charset "UTF-8";
+
+:root,
+:host {
+  --tag-green: #43a047aa;
+  --tag-pink: #f24b59aa;
+  --tag-blue: #2698fbaa;
+
+  --selected-highlight: var(--primary-highlight);
+  --selected-bg: #fffde5;
+  --selected-reading-highlight: #2e7d32;
+  --selected-conj-color: #fc7600;
+  --selected-def-color: #1a1d1f;
+  --selected-tag-color: #1a1d1f;
+  --selected-tag-border: rgba(0, 0, 0, 0.3);
+}
+
+/*
+ * Theme - light
+ */
+
+.window,
+.window.-light,
+.puck,
+.puck.-light {
+  --text-color: #1d1a19;
+  --bg-color: #f6f1f0;
+  --border-color: #706c6b;
+
+  --primary-highlight: #1f66c7;
+  --reading-highlight: #43a047;
+  --conj-color: #1a47a8;
+
+  --tag-border: rgba(0, 0, 0, 0.3);
+
+  --title-fg: var(--text-color);
+  --title-bg: #ddd8d7;
+
+  --reading-label: #1b5e20;
+  --okurigana-color: #fc7600;
+  --cell-highlight-bg: #ede8e6;
+  --cell-highlight-fg: #1d1a19;
+
+  --meta-bg: var(--cell-highlight-bg);
+  --copy-status-bg: var(--cell-highlight-bg);
+}
+
+/*
+ * Theme - blue
+ */
+
+.window.-blue,
+.puck.-blue {
+  --text-color: white;
+  --bg-color: #446ea0;
+  --border-color: #17588e;
+
+  --primary-highlight: #bcdffe;
+  --reading-highlight: #c0ffc0;
+  --conj-color: #fff394;
+
+  --tag-border: rgba(255, 255, 255, 0.4);
+
+  --title-bg: var(--cell-highlight-bg);
+  --title-fg: var(--text-color);
+
+  --reading-label: #e7ffe7;
+  --okurigana-color: #a8cfef;
+  --cell-highlight-bg: #17588e;
+  --cell-highlight-fg: var(--primary-highlight);
+
+  --selected-highlight: var(--bg-color);
+
+  --copy-status-bg: rgba(255, 255, 255, 0.2);
+  --meta-bg: rgba(255, 255, 255, 0.2);
+}
+
+/*
+ * Theme - black
+ */
+
+.window.-black,
+.puck.-black {
+  --text-color: white;
+  --bg-color: #3e3a39;
+  --border-color: #999493;
+
+  --primary-highlight: #65b7fc;
+  --reading-highlight: #a5d6a7;
+  --conj-color: #817470;
+
+  --tag-border: rgba(255, 255, 255, 0.4);
+
+  --title-bg: #1d1a19;
+  --title-fg: #ede8e6;
+
+  --reading-label: #e7ffe7;
+  --okurigana-color: #ede8e6;
+  --cell-highlight-bg: #5d5857;
+  --cell-highlight-fg: #ede8e6;
+
+  --selected-highlight: #2277d9;
+
+  --copy-status-bg: rgba(255, 255, 255, 0.2);
+  --meta-bg: rgba(255, 255, 255, 0.2);
+}
+
+.window.-black .kanji-table:not(.-copy) .kanji {
+  text-shadow: rgba(255, 255, 255, 0.2) 1px 1px 4px;
+}
+
+/*
+ * Theme - lightblue
+ */
+
+.window.-lightblue,
+.puck.-lightblue {
+  --text-color: #1d1a19;
+  --bg-color: #e3f2fe;
+  --border-color: #65b7fc;
+
+  --primary-highlight: #17588e;
+  --reading-highlight: #2e7d32;
+  --conj-color: #817470;
+
+  --tag-border: rgba(0, 0, 0, 0.3);
+
+  --title-fg: var(--text-color);
+  --title-bg: #bcdffe;
+
+  --reading-label: #1b5e20;
+  --okurigana-color: #706c6b;
+  --cell-highlight-bg: #cae6fc;
+  --cell-highlight-fg: var(--primary-highlight);
+
+  --selected-highlight: var(--primary-highlight);
+
+  --meta-bg: var(--cell-highlight-bg);
+  --copy-status-bg: var(--cell-highlight-bg);
+}
+
+/*
+ * Theme - yellow
+ */
+
+.window.-yellow,
+.puck.-yellow {
+  --text-color: #1d1a19;
+  --bg-color: #fff8bf;
+  --border-color: #ffd600;
+
+  --primary-highlight: #17588e;
+  --reading-highlight: #2e7d32;
+  --conj-color: #fc7600;
+
+  --tag-border: rgba(0, 0, 0, 0.3);
+
+  --title-bg: #fffde5;
+  --title-fg: var(--text-color);
+
+  --reading-label: #1b5e20;
+  --okurigana-color: #fc7600;
+  --cell-highlight-bg: #fffde5;
+  --cell-highlight-fg: #3e3a39;
+
+  --selected-bg: #e3f2fe;
+  --selected-highlight: var(--primary-highlight);
+
+  --meta-bg: var(--cell-highlight-bg);
+  --copy-status-bg: var(--cell-highlight-bg);
+}

--- a/src/content-container.ts
+++ b/src/content-container.ts
@@ -1,0 +1,142 @@
+import { getHash } from './hash';
+import { isForeignObjectElement, isSvgDoc, SVG_NS } from './svg';
+
+export function getOrCreateEmptyContainer({
+  doc,
+  id,
+  legacyIds,
+  styles,
+}: {
+  doc: Document;
+  id: string;
+  legacyIds?: Array<string>;
+  styles: string;
+}): HTMLElement {
+  // Drop any legacy containers
+  if (legacyIds?.length) {
+    const legacyContainers = doc.querySelectorAll(
+      legacyIds.map((id) => `#${id}`).join(', ')
+    );
+    for (const container of legacyContainers) {
+      removeContainerElement(container);
+    }
+  }
+
+  // Look for an existing container we can re-use
+  const existingContainers = Array.from<HTMLElement>(
+    doc.querySelectorAll(`#${id}`)
+  );
+  if (existingContainers.length) {
+    // Drop any duplicate containers, returning only the last one
+    while (existingContainers.length > 1) {
+      removeContainerElement(existingContainers.shift()!);
+    }
+
+    // Drop any existing content (except styles)
+    resetContent(existingContainers[0]);
+
+    // Make sure the styles are up-to-date
+    resetStyles({ container: existingContainers[0], doc, styles });
+
+    return existingContainers[0];
+  }
+
+  // We didn't find an existing content container so create a new one
+
+  // For SVG documents we put container <div> inside a <foreignObject>.
+  let parent: Element;
+  if (isSvgDoc(doc)) {
+    const foreignObject = doc.createElementNS(SVG_NS, 'foreignObject');
+    foreignObject.setAttribute('width', '100%');
+    foreignObject.setAttribute('height', '100%');
+    doc.documentElement.append(foreignObject);
+    parent = foreignObject;
+  } else {
+    parent = doc.documentElement;
+  }
+
+  // Actually create the container element
+  const container = doc.createElement('div');
+  container.id = id;
+  parent.append(container);
+
+  // Reset any styles the page may have applied.
+  container.style.all = 'initial';
+
+  // Add the necessary style element
+  resetStyles({ container, doc, styles });
+
+  return container;
+}
+
+export function removeContentContainer(id: string | Array<string>) {
+  const containerIds = typeof id === 'string' ? [id] : id;
+  const containers = Array.from<HTMLElement>(
+    document.querySelectorAll(containerIds.map((id) => `#${id}`).join(', '))
+  );
+  for (const container of containers) {
+    removeContainerElement(container);
+  }
+}
+
+// --------------------------------------------------------------------------
+//
+// Implementation helpers
+//
+// --------------------------------------------------------------------------
+
+function removeContainerElement(elem: Element) {
+  if (isForeignObjectElement(elem.parentElement)) {
+    elem.parentElement.remove();
+  } else {
+    elem.remove();
+  }
+}
+
+function resetContent(elem: HTMLElement) {
+  if (!elem.shadowRoot) {
+    return;
+  }
+
+  for (const child of elem.shadowRoot!.children) {
+    if (child.tagName !== 'STYLE') {
+      child.remove();
+    }
+  }
+}
+
+function resetStyles({
+  container,
+  doc,
+  styles,
+}: {
+  container: HTMLElement;
+  doc: Document;
+  styles: string;
+}) {
+  const styleHash = getHash(styles);
+
+  if (!container.shadowRoot) {
+    container.attachShadow({ mode: 'open' });
+
+    // Add <style>
+    const style = doc.createElement('style');
+    style.textContent = styles;
+    style.dataset.hash = styleHash;
+    container.shadowRoot!.append(style);
+  } else {
+    // Reset style
+    let existingStyle = container.shadowRoot.querySelector('style');
+    if (existingStyle && existingStyle.dataset.hash !== styleHash) {
+      existingStyle.remove();
+      existingStyle = null;
+    }
+
+    if (!existingStyle) {
+      const style = doc.createElement('style');
+      style.textContent = styles;
+      style.dataset.hash = styleHash;
+      container.shadowRoot!.append(style);
+    }
+  }
+}

--- a/src/content.ts
+++ b/src/content.ts
@@ -850,10 +850,7 @@ export class ContentHandler {
       return;
     }
 
-    const doc: Document = this.currentTarget
-      ? this.currentTarget.ownerDocument!
-      : window.document;
-
+    const doc: Document = this.currentTarget?.ownerDocument ?? window.document;
     const popupOptions: PopupOptions = {
       accentDisplay: this.config.accentDisplay,
       copyIndex: this.copyIndex,
@@ -1024,9 +1021,14 @@ declare global {
   //
   let port: Browser.Runtime.Port | undefined;
 
+  // Selection puck
+  const puck = new RikaiPuck();
+  let theme = 'default';
+
   window.readerScriptVer = __VERSION__;
   window.removeReaderScript = () => {
     disable();
+    puck.unmount();
     browser.runtime.onMessage.removeListener(onMessage);
   };
 
@@ -1047,6 +1049,18 @@ declare global {
     });
   }
 
+  // Render the puck
+  if (document.readyState !== 'loading') {
+    renderPuck();
+  } else {
+    window.addEventListener('DOMContentLoaded', renderPuck);
+  }
+
+  function renderPuck() {
+    puck.render({ doc: document, theme });
+    puck.enable();
+  }
+
   function onMessage(request: any): Promise<string> {
     if (typeof request.type !== 'string') {
       return Promise.reject(
@@ -1060,6 +1074,11 @@ declare global {
           typeof request.config === 'object',
           'No config object provided with enable message'
         );
+
+        if (request.config.popupStyle !== theme) {
+          theme = request.config.popupStyle;
+          puck.setTheme(theme);
+        }
 
         const tabId: number | undefined =
           typeof request.id === 'number' ? request.id : undefined;
@@ -1135,24 +1154,6 @@ declare global {
 
   function onPageHide() {
     browser.runtime.sendMessage({ type: 'disabled' });
-  }
-
-  function onDOMContentLoaded(): void {
-    const rp = new RikaiPuck();
-    rp.render(document.body);
-    rp.enable();
-  }
-
-  if (document?.readyState === "interactive") {
-    onDOMContentLoaded();
-  } else {
-    window.addEventListener(
-      'DOMContentLoaded',
-      onDOMContentLoaded,
-      {
-        once: true,
-      },
-    );
   }
 })();
 

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -13,12 +13,15 @@ import { browser } from 'webextension-polyfill-ts';
 
 import { AccentDisplay, PartOfSpeechDisplay } from './content-config';
 import {
+  getOrCreateEmptyContainer,
+  removeContentContainer,
+} from './content-container';
+import {
   CopyKeys,
   CopyType,
   CopyKanjiKeyStrings,
   CopyNextKeyStrings,
 } from './copy-keys';
-import { getHash } from './hash';
 import { SelectionMeta } from './meta';
 import { QueryResult } from './query';
 import {
@@ -27,7 +30,7 @@ import {
   ReferenceAbbreviation,
 } from './refs';
 import { NameResult, Sense, WordResult } from './search-result';
-import { isForeignObjectElement, isSvgDoc, SVG_NS } from './svg';
+import { SVG_NS } from './svg';
 import { EraInfo, getEraInfo } from './years';
 
 import popupStyles from '../css/popup.css';
@@ -65,7 +68,8 @@ export function renderPopup(
 ): HTMLElement {
   const doc = options.document || document;
   const container = options.container || getDefaultContainer(doc);
-  const windowElem = resetContainer(container, {
+  const windowElem = resetContainer({
+    container,
     document: doc,
     popupStyle: options.popupStyle,
   });
@@ -100,173 +104,69 @@ export function renderPopup(
 }
 
 function getDefaultContainer(doc: Document): HTMLElement {
-  // Look for an existing container
-  const existingContainers = doc.querySelectorAll(
-    '#rikaichamp-window, #tenten-ja-window'
-  );
-  if (existingContainers.length) {
-    // Drop any duplicate containers
-    while (existingContainers.length > 1) {
-      existingContainers[1].remove();
-    }
-    return existingContainers[0] as HTMLElement;
+  return getOrCreateEmptyContainer({
+    doc,
+    id: 'tenten-ja-window',
+    legacyIds: ['rikaichamp-window'],
+    styles: popupStyles.toString(),
+  });
+}
+
+function resetContainer({
+  container,
+  document: doc,
+  popupStyle,
+}: {
+  container: HTMLElement;
+  document: Document;
+  popupStyle: string;
+}): HTMLElement {
+  const windowDiv = doc.createElement('div');
+  windowDiv.classList.add('window');
+  if (popupStyle !== 'default') {
+    windowDiv.classList.add(`-${popupStyle}`);
+  } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    // We don't bother registering an event listener for the
+    // prefers-color-scheme media query since the popup is so short-lived.
+    windowDiv.classList.add('-black');
   }
 
-  // Create a new container
-
-  // For SVG documents we put container <div> inside a <foreignObject>.
-  let parent: Element;
-  if (isSvgDoc(doc)) {
-    const foreignObject = doc.createElementNS(SVG_NS, 'foreignObject');
-    foreignObject.setAttribute('width', '600');
-    foreignObject.setAttribute('height', '100%');
-    doc.documentElement.append(foreignObject);
-    parent = foreignObject;
+  if (container.shadowRoot) {
+    container.shadowRoot.append(windowDiv);
   } else {
-    parent = doc.documentElement;
+    container.append(windowDiv);
   }
-
-  // Actually create the container element
-  const container = doc.createElement('div');
-  container.id = 'tenten-ja-window';
-  parent.append(container);
-
-  // Apply minimal container styles
-  //
-  // All the interesting styles go on the inner 'window' object. The styles here
-  // are just used for positioning the pop-up correctly.
-  //
-  // First reset all styles the page may have applied.
-  container.style.all = 'initial';
-  container.style.position = 'absolute';
-  // asahi.com puts z-index: 1000000 on its banner ads. We go one better.
-  container.style.zIndex = '1000001';
-  // Make sure the drop shadow doesn't get cut off
-  container.style.paddingRight = '4px';
-  container.style.paddingBottom = '4px';
 
   // Set initial position
   container.style.top = '5px';
   container.style.left = '5px';
   container.style.minWidth = '100px';
 
-  // Enforce any max-height set on the container.
-  container.style.overflowY = 'hidden';
-
-  // Make sure the container too doesn't receive pointer events
-  container.style.pointerEvents = 'none';
-
-  return container;
-}
-
-function resetContainer(
-  container: HTMLElement,
-  { document: doc, popupStyle }: { document: Document; popupStyle: string }
-): HTMLElement {
-  if (!container.shadowRoot) {
-    container.attachShadow({ mode: 'open' });
-
-    // Add <style>
-    const style = doc.createElement('style');
-    style.textContent = popupStyles;
-    style.dataset.hash = getStyleHash();
-    container.shadowRoot!.append(style);
-  } else {
-    // Reset content
-    for (const child of container.shadowRoot!.children) {
-      if (child.tagName !== 'STYLE') {
-        child.remove();
-      }
-    }
-
-    // Reset style
-    let existingStyle = container.shadowRoot.querySelector('style');
-    if (existingStyle && existingStyle.dataset.hash !== getStyleHash()) {
-      existingStyle.remove();
-      existingStyle = null;
-    }
-
-    if (!existingStyle) {
-      const style = doc.createElement('style');
-      style.textContent = popupStyles;
-      style.dataset.hash = getStyleHash();
-      container.shadowRoot!.append(style);
-    }
-  }
-
-  const windowDiv = doc.createElement('div');
-  windowDiv.classList.add('window');
-  if (popupStyle !== 'default') {
-    windowDiv.classList.add(`-${popupStyle}`);
-  } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-    // We don't bother registering an event listener for this since the popup is
-    // so short-lived.
-    windowDiv.classList.add('-black');
-  }
-  container.shadowRoot!.append(windowDiv);
-
-  // Reset the container position so we can consistently measure the size of
-  // the popup
-  container.style.left = '5px';
-  container.style.top = '5px';
-  container.style.maxWidth = 'initial';
-  container.style.maxHeight = 'initial';
+  // Reset the container position and size so that we can consistently measure
+  // the size of the popup.
+  container.style.removeProperty('left');
+  container.style.removeProperty('top');
+  container.style.removeProperty('max-width');
+  container.style.removeProperty('max-height');
 
   return windowDiv;
 }
 
-let styleHash: string | undefined;
-
-function getStyleHash(): string {
-  if (!styleHash) {
-    styleHash = getHash(popupStyles.toString());
-  }
-
-  return styleHash;
-}
-
 export function isPopupVisible(): boolean {
-  const popup = document.getElementById('tenten-ja-window');
-  if (!popup || !popup.shadowRoot) {
-    return false;
-  }
-
-  const windowElem = popup.shadowRoot.querySelector('.window');
-  return !!windowElem && !windowElem.classList.contains('hidden');
+  const popupWindow = getPopupWindow();
+  return !!popupWindow && !popupWindow.classList.contains('hidden');
 }
 
 export function hidePopup() {
-  const popup = document.getElementById('tenten-ja-window');
-  if (!popup || !popup.shadowRoot) {
-    return;
-  }
-
-  const windowElem = popup.shadowRoot.querySelector('.window');
-  if (windowElem) {
-    windowElem.classList.add('hidden');
-  }
+  getPopupWindow()?.classList.add('hidden');
 }
 
 export function removePopup() {
-  let popup = document.querySelector('#rikaichamp-window, #tenten-ja-window');
-  while (popup) {
-    // If we are in an SVG document, remove the wrapping <foreignObject>.
-    if (isForeignObjectElement(popup.parentElement)) {
-      popup.parentElement.remove();
-    } else {
-      popup.remove();
-    }
-    popup = document.querySelector('#rikaichamp-window, #tenten-ja-window');
-  }
+  removeContentContainer(['rikaichamp-window', 'tenten-ja-window']);
 }
 
 export function setPopupStyle(style: string) {
-  const popup = document.getElementById('tenten-ja-window');
-  if (!popup || !popup.shadowRoot) {
-    return;
-  }
-
-  const windowElem = popup.shadowRoot.querySelector('.window');
+  const windowElem = getPopupWindow();
   if (!windowElem) {
     return;
   }
@@ -278,6 +178,13 @@ export function setPopupStyle(style: string) {
   }
 
   windowElem.classList.add(`-${style}`);
+}
+
+function getPopupWindow(): HTMLElement | null {
+  const contentContainer = document.getElementById('tenten-ja-window');
+  return contentContainer && contentContainer.shadowRoot
+    ? contentContainer.shadowRoot.querySelector('.window')
+    : null;
 }
 
 function renderWordEntries(

--- a/src/puck.ts
+++ b/src/puck.ts
@@ -127,6 +127,7 @@ export class RikaiPuck {
   unmount(): void {
     removeContentContainer('tenten-ja-puck');
     this.disable();
+    this.puck = undefined;
   }
 
   enable(): void {

--- a/src/puck.ts
+++ b/src/puck.ts
@@ -1,111 +1,151 @@
-export interface PuckOpts {
-  width: number;
-  height: number;
-  borderColor: string;
-  backgroundColor: string;
-}
+import {
+  getOrCreateEmptyContainer,
+  removeContentContainer,
+} from './content-container';
+
+import puckStyles from '../css/puck.css';
 
 export class RikaiPuck {
-  private readonly puck: HTMLDivElement = document.createElement("div");
-  private static defaultOpts: PuckOpts = {
-    width: 50,
-    height: 50,
-    borderColor: "#b7e7ff",
-    backgroundColor: "#5c73b8",
-  };
-  private _puckX: number;
-  private get puckX(): number {
-    return this._puckX;
-  }
-  private set puckX(x: number){
-    this._puckX = x;
-    this.puck.style.transform = `translate(${x}px, ${this.puckY}px)`;
-  }
-  private _puckY: number;
-  private get puckY(): number {
-    return this._puckY;
-  }
-  private set puckY(y: number){
-    this._puckY = y;
-    this.puck.style.transform = `translate(${this.puckX}px, ${y}px)`;
+  private puck: HTMLDivElement | undefined;
+  private enabled = false;
+
+  private puckX: number;
+  private puckY: number;
+  private puckWidth: number;
+  private puckHeight: number;
+
+  private setPosition(x: number, y: number) {
+    this.puckX = x;
+    this.puckY = y;
+    if (this.puck) {
+      this.puck.style.transform = `translate(${this.puckX}px, ${this.puckY}px)`;
+    }
   }
 
-  private _puckWidth: number;
-  private get puckWidth(): number {
-    return this._puckWidth;
-  }
-  private set puckWidth(width: number){
-    this._puckWidth = width;
-    this.puck.style.width = `${width}px`;
-  }
-  private _puckHeight: number;
-  private get puckHeight(): number {
-    return this._puckHeight;
-  }
-  private set puckHeight(height: number){
-    this._puckHeight = height;
-    this.puck.style.height = `${height}px`;
-  }
+  private readonly onPointerMove = (event: PointerEvent) => {
+    if (!this.puckWidth || !this.puckHeight || !this.enabled) {
+      return;
+    }
 
-  constructor(opts: Partial<PuckOpts> = RikaiPuck.defaultOpts){
-    const {
-      width,
-      height,
-      backgroundColor,
-      borderColor,
-    } = Object.assign({}, RikaiPuck.defaultOpts, opts);
-
-    this.puck.style.position = "fixed";
-    this.puckWidth = width;
-    this.puckHeight = height;
-    this.puck.style.top = "0";
-    this.puck.style.left = "0";
-    this.puck.style.boxSizing = "border-box";
-    this.puck.style.backgroundColor = backgroundColor;
-    this.puck.style.touchAction = "manipulation";
-    this.puck.style.borderRadius = "15px";
-    this.puck.style.border = `2px solid ${borderColor}`;
-    // We use a z-index one higher than the Rikai popup itself.
-    this.puck.style.zIndex = "1000002";
-  }
-  private readonly onPointermove = (event: PointerEvent) => {
     event.preventDefault();
-    const { clientX, clientY } = event;
-    this.puckX = clientX - this.puckWidth / 2;
-    this.puckY = clientY - this.puckHeight / 2;
-    window.dispatchEvent(
-      new MouseEvent(
-        "mousemove",
-        {
-          clientX: this.puckX,
-          // Offset by at least one pixel so that Rikai doesn't attempt to tunnel into the puck rather than the text.
-          clientY: this.puckY - 1,
-        }
-      )
-    );
-  }
 
-  render(parent: HTMLElement): void {
+    const { clientX, clientY } = event;
+    this.setPosition(
+      clientX - this.puckWidth / 2,
+      clientY - this.puckHeight / 2
+    );
+
+    // Work out where we want to lookup
+    const targetX = this.puckX;
+    // Offset by at least one pixel so that Rikai doesn't attempt to tunnel into
+    // the puck rather than the text.
+    const targetY = this.puckY - 1;
+
+    // Make sure the target is an actual element since the mousemove handler
+    // expects that.
+    const target = document.elementFromPoint(targetX, targetY);
+    if (target) {
+      target.dispatchEvent(
+        new MouseEvent('mousemove', {
+          // Make sure the event bubbles up to the listener on the window
+          bubbles: true,
+          clientX: targetX,
+          clientY: targetY,
+        })
+      );
+    }
+  };
+
+  // Prevent any mouse events on the puck itself from being used for lookup.
+  //
+  // At least in Firefox we can get _both_ pointer events and mouse events being
+  // dispatched.
+  private readonly onMouseMove = (event: MouseEvent) => {
+    event.stopPropagation();
+  };
+
+  render({ doc, theme }: { doc: Document; theme: string }): void {
+    // Set up shadow tree
+    const container = getOrCreateEmptyContainer({
+      doc,
+      id: 'tenten-ja-puck',
+      styles: puckStyles.toString(),
+    });
+
+    // Create puck elem
+    this.puck = doc.createElement('div');
+    this.puck.classList.add('puck');
+    container.shadowRoot!.append(this.puck);
+
+    // Set theme styles
+    if (theme !== 'default') {
+      this.puck.classList.add(`-${theme}`);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      this.puck.classList.add('-black');
+    }
+
+    // Calculate the puck size
+    if (!this.puckWidth || !this.puckHeight) {
+      const { width, height } = this.puck.getBoundingClientRect();
+      this.puckWidth = width;
+      this.puckHeight = height;
+    }
+
+    // Calculate the initial position
     const viewportWidth = document.documentElement.clientWidth;
     const viewportHeight = document.documentElement.clientHeight;
     const safeAreaInsetRight = 16; // TODO: calculate properly
     const safeAreaInsetBottom = 200; // TODO: calculate properly
-    this.puckX = viewportWidth - this.puckWidth - safeAreaInsetRight;
-    this.puckY = viewportHeight - this.puckHeight - safeAreaInsetBottom;
+    this.setPosition(
+      viewportWidth - this.puckWidth - safeAreaInsetRight,
+      viewportHeight - this.puckHeight - safeAreaInsetBottom
+    );
 
-    parent.appendChild(this.puck);
+    // Add event listeners
+    if (this.enabled) {
+      this.puck.addEventListener('pointermove', this.onPointerMove);
+      this.puck.addEventListener('mousemove', this.onMouseMove, {
+        capture: true,
+      });
+    }
+  }
+
+  setTheme(theme: string) {
+    if (!this.puck) {
+      return;
+    }
+
+    for (const className of this.puck.classList.values()) {
+      if (className.startsWith('-')) {
+        this.puck.classList.remove(className);
+      }
+    }
+
+    this.puck.classList.add(`-${theme}`);
   }
 
   unmount(): void {
-    this.puck.parentElement?.removeChild(this.puck);
+    removeContentContainer('tenten-ja-puck');
     this.disable();
   }
 
   enable(): void {
-    this.puck.addEventListener("pointermove", this.onPointermove);
+    this.enabled = true;
+    if (this.puck) {
+      this.puck.addEventListener('pointermove', this.onPointerMove);
+      this.puck.addEventListener('mousemove', this.onMouseMove, {
+        capture: true,
+      });
+    }
   }
 
   disable(): void {
-    this.puck.removeEventListener("pointermove", this.onPointermove);
+    this.enabled = false;
+    if (this.puck) {
+      this.puck.removeEventListener('pointermove', this.onPointerMove);
+      this.puck.removeEventListener('mousemove', this.onMouseMove, {
+        capture: true,
+      });
+    }
   }
 }


### PR DESCRIPTION
This is a revision of #1 that uses two shadow DOM trees instead of 2